### PR TITLE
redirecting testparm STDERR to null

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -226,8 +226,8 @@ function parse_config() {
 		return FALSE;
 	}
 
-	exec('testparm -s ' . escapeshellarg($smb_config_file), $config_text);
-	foreach ($config_text as $line) {
+	exec('testparm -s ' . escapeshellarg($smb_config_file) . ' 2> /dev/null', $config_text);
+	foreach ($config_text) as $line) {
 		$line = trim($line);
 		if (mb_strlen($line) == 0) { continue; }
 		if ($line[0] == '[' && preg_match('/\[([^\]]+)\]/', $line, $regs)) {


### PR DESCRIPTION
woops!  sorry, i missed this before - testparm sends a bunch of diagnostic info to STDERR before outputting the compiled config to STDOUT.  this resulted in that diagnostic info being sent to the user when you run commands from the CLI like "greyhole -L"

i'm just sending STDERR to /dev/null here.  a show-stopping error from testparm would be a show-stopping error for samba, so i don't _think_ there's a danger in doing this.
