### PR TITLE
Samba 4.0 Module Patch update

### DIFF
--- a/samba-module/wscript-samba-4.0.patch
+++ b/samba-module/wscript-samba-4.0.patch
@@ -1,41 +1,28 @@
-*** a/source3/modules/wscript_build	Tue Nov 13 10:03:38 2012
---- b/source3/modules/wscript_build	Wed Jan 16 22:33:25 2013
+*** a/source3/modules/wscript_build	2013-04-09 03:14:59.000000000 -0500
+--- b/source3/modules/wscript_build	2013-05-05 19:12:56.047888856 -0500
 ***************
-*** 50,57 ****
---- 50,66 ----
+*** 50,55 ****
+--- 50,65 ----
   VFS_LINUX_XFS_SGID_SRC = 'vfs_linux_xfs_sgid.c'
   VFS_TIME_AUDIT_SRC = 'vfs_time_audit.c'
   VFS_MEDIA_HARMONY_SRC = 'vfs_media_harmony.c'
 + VFS_GREYHOLE_SRC = 'vfs_greyhole.c'
-  
-  
-+ bld.SAMBA3_MODULE('vfs_greyhole',
-+                  subsystem='vfs',
-+                  source=VFS_GREYHOLE_SRC,
-+                  deps='',
-+                  init_function='',
-+                  internal_module=bld.SAMBA3_IS_STATIC_MODULE('vfs_greyhole'),
-+                  enabled=bld.SAMBA3_IS_ENABLED_MODULE('vfs_greyhole'))
 + 
++ bld.SAMBA3_MODULE('vfs_greyhole',
++                   subsystem='vfs',
++                   source=VFS_GREYHOLE_SRC,
++                   deps='',
++                   init_function='',
++                   internal_module=bld.SAMBA3_IS_STATIC_MODULE('vfs_greyhole'),
++                   enabled=bld.SAMBA3_IS_ENABLED_MODULE('vfs_greyhole'))
++ 
+  
+  
   bld.SAMBA3_SUBSYSTEM('NFS4_ACLS',
-                      source='nfs4_acls.c',
-                      deps='samba-util tdb')
-*** a/source3/wscript	Tue Dec  4 12:07:44 2012
---- b/source3/wscript	Wed Jan 16 22:50:24 2013
+*** a/source3/wscript	2013-04-09 03:14:59.000000000 -0500
+--- b/source3/wscript	2013-05-05 19:19:58.380817099 -0500
 ***************
-*** 1693,1699 ****
-                                        auth_script vfs_readahead vfs_xattr_tdb vfs_posix_eadb
-                                        vfs_streams_xattr vfs_streams_depot vfs_acl_xattr vfs_acl_tdb
-                                        vfs_smb_traffic_analyzer vfs_preopen vfs_catia vfs_scannedonly
+*** 1696 ****
 ! 				      vfs_media_harmony
-                                        vfs_crossrename vfs_linux_xfs_sgid
-                                        vfs_time_audit idmap_autorid idmap_tdb2
-                                        idmap_rid idmap_hash'''))
---- 1693,1699 ----
-                                        auth_script vfs_readahead vfs_xattr_tdb vfs_posix_eadb
-                                        vfs_streams_xattr vfs_streams_depot vfs_acl_xattr vfs_acl_tdb
-                                        vfs_smb_traffic_analyzer vfs_preopen vfs_catia vfs_scannedonly
+--- 1696 ----
 ! 				      vfs_media_harmony vfs_greyhole
-                                        vfs_crossrename vfs_linux_xfs_sgid
-                                        vfs_time_audit idmap_autorid idmap_tdb2
-                                        idmap_rid idmap_hash'''))


### PR DESCRIPTION
Changed `wscript-samba-4.0.patch` so it works with any Samba 4.0.x version. Tested patching 4.0.0 through latest, which at time of this patch is 4.0.5
