### PR TITLE
package php-intl does not exist on apt-get

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,7 +24,7 @@ Note: Samba 3.4.3 (and 3.3.9) fix a bug that affects Greyhole functionnality.
 1. Install the required applications: PHP 5+ (cli) with MySQL & mbstring extensions, MySQL server, Samba, rsync, GCC (etc.):
 
 	Fedora: yum -y install mysql-server php php-mysql php-mbstring php-intl samba samba-common patch gcc yum-utils php-pear rsync lsof
-	Ubuntu: apt-get -y install mysql-server php5-cli php5-mysql php-intl samba samba-common samba-common-bin build-essential php-pear rsync lsof
+	Ubuntu: apt-get -y install mysql-server php5-cli php5-mysql php5-intl samba samba-common samba-common-bin build-essential php-pear rsync lsof
 
 2. Install Greyhole (as root):
 


### PR DESCRIPTION
following the instructions in the INSTALL file for Ubuntu distro, I discovered an error in one of the package names. php-intl does not exist, however searching the repo I found that a package named "php5-intl" does. I am only speculating that this package fulfills the same dependancies.
