### PR TITLE
Clarification on what trash does

### DIFF
--- a/greyhole.example.conf
+++ b/greyhole.example.conf
@@ -1,4 +1,3 @@
-
 # This file is part of Greyhole.
 
 #### Database Connection ####
@@ -185,8 +184,9 @@
 	df_cache_time = 15
 
 #### Trash ####
-# Move deleted files to trash, instead of deleting them?
-# (Yes, trash is just another name for a Recycle Bin.)
+# Move deleted or modified files (think of it as a file backup
+# in case of a mistake) to trash, instead of deleting them?
+# ( Yes, trash is just another name for a Recycle Bin. )
 # You can specify per-share preferences that will override the global 
 # preference.
 


### PR DESCRIPTION
Trash does not just keep files that have been deleted. Files that have been modified are also saved in trash as a revision backup for scenarios when a user may of made a mistake and wishes to revert. Or in the hopefully unlikely event that greyhole does something it was not meant to have done.
