### PR TITLE
Split functionality of setting delete_moves_to_trash

### DIFF
--- a/DEBIAN/Makefile
+++ b/DEBIAN/Makefile
@@ -6,7 +6,7 @@ deb: build
 	rm greyhole
 	rm greyhole-dfree
 	rm greyhole-dfree.php
-	rm greyhole-mv
+#	rm greyhole-mv
 	rm logrotate.greyhole
 	rm schema-mysql.sql
 	rm schema-sqlite.sql

--- a/greyhole
+++ b/greyhole
@@ -846,8 +846,11 @@ function gh_write($share, $full_path, $task_id) {
                     }
                 }
                 if ($is_ok) {
-                    // Ok, now we're sure.
-                    gh_recycle($source_file);
+                    // check if setting is enabled
+                    if (SharesConfig::get($share, CONFIG_MODIFIED_MOVES_TO_TRASH)) {
+                        // Ok, now we're sure.
+                        gh_recycle($source_file);
+                    }
                 } else {
                     Log::debug("  Change of mind... Couldn't find any OK metadata file... Will keep the source!");
                 }
@@ -913,7 +916,11 @@ function gh_write_process_metafiles($num_copies_required, $existing_metafiles, $
     if ($keys_to_remove !== NULL) {
         foreach ($keys_to_remove as $key) {
             if ($existing_metafiles[$key]->path != $source_file) {
-                gh_recycle($existing_metafiles[$key]->path);
+                // check if setting is enabled
+                if (SharesConfig::get($share, CONFIG_MODIFIED_MOVES_TO_TRASH)) {
+                    // Ok, now we're sure.
+                    gh_recycle($existing_metafiles[$key]->path);
+                }
             }
         }
         // Empty the existing metafiles array, to be able to recreate all new copies on the correct drives, per the dir_selection_algorithm

--- a/greyhole.example.conf
+++ b/greyhole.example.conf
@@ -1,4 +1,3 @@
-
 # This file is part of Greyhole.
 
 #### Database Connection ####
@@ -184,15 +183,27 @@
 
 	df_cache_time = 15
 
-#### Trash ####
+#### Delete to Trash ####
 # Move deleted files to trash, instead of deleting them?
-# (Yes, trash is just another name for a Recycle Bin.)
+# ( Yes, trash is just another name for a Recycle Bin. )
+# This is useful in scenarios where you accidently deleted a file.
 # You can specify per-share preferences that will override the global 
 # preference.
 
 	delete_moves_to_trash = yes
 #	delete_moves_to_trash[CrashPlan] = no
 #	delete_moves_to_trash[TimeMachine] = no
+
+#### Modified to Trash
+# Move modified files to trash, instead of deleting them?
+# This is useful in scenarios when you accidently saved a file
+# and want to revert back.
+# You can specify per-share preferences that will override the global
+# preference
+	
+	modified_moves_to_trash = yes
+#	modified_moves_to_trash[CrashPlan] = no
+#	modified_moves_to_trash[TimeMachine] = no
 
 #### Frozen directories ####
 # Directories listed below will not be touched by Greyhole until the user 

--- a/includes/ConfigHelper.php
+++ b/includes/ConfigHelper.php
@@ -20,6 +20,7 @@ along with Greyhole.  If not, see <http://www.gnu.org/licenses/>.
 
 define('CONFIG_LOG_LEVEL', 'log_level');
 define('CONFIG_DELETE_MOVES_TO_TRASH', 'delete_moves_to_trash');
+define('CONFIG_MODIFIED_MOVES_TO_TRASH', 'modified_moves_to_trash');
 define('CONFIG_LOG_MEMORY_USAGE', 'log_memory_usage');
 define('CONFIG_CHECK_FOR_OPEN_FILES', 'check_for_open_files');
 define('CONFIG_ALLOW_MULTIPLE_SP_PER_DRIVE', 'allow_multiple_sp_per_device');
@@ -107,6 +108,7 @@ class ConfigHelper {
 
                     // Booleans
                     case CONFIG_DELETE_MOVES_TO_TRASH:
+                    case CONFIG_MODIFIED_MOVES_TO_TRASH:
                     case CONFIG_LOG_MEMORY_USAGE:
                     case CONFIG_CHECK_FOR_OPEN_FILES:
                     case CONFIG_ALLOW_MULTIPLE_SP_PER_DRIVE:
@@ -201,6 +203,11 @@ class ConfigHelper {
                             $value = strtolower(trim($value));
                             $bool = trim($value) === '1' || mb_stripos($value, 'yes') !== FALSE || mb_stripos($value, 'true') !== FALSE;
                             SharesConfig::set($share, CONFIG_DELETE_MOVES_TO_TRASH, $bool);
+                        } else if (string_starts_with($name, CONFIG_MODIFIED_MOVES_TO_TRASH)) {
+                            $share = mb_substr($name, 24, mb_strlen($name)-25);
+                            $value = strtolower(trim($value));
+                            $bool = trim($value) === '1' || mb_stripos($value, 'yes') !== FALSE || mb_stripos($value, 'true') !== FALSE;
+                            SharesConfig::set($share, CONFIG_MODIFIED_MOVES_TO_TRASH, $bool);
                         } else if (string_starts_with($name, CONFIG_DRIVE_SELECTION_GROUPS)) {
                             $share = mb_substr($name, 23, mb_strlen($name)-24);
                             if (preg_match("/(.+):(.+)/", $value, $regs)) {
@@ -295,6 +302,9 @@ class ConfigHelper {
             if (!isset($share_options[CONFIG_DELETE_MOVES_TO_TRASH])) {
                 SharesConfig::set($share_name, CONFIG_DELETE_MOVES_TO_TRASH, Config::get(CONFIG_DELETE_MOVES_TO_TRASH));
             }
+            if (!isset($share_options[CONFIG_MODIFIED_MOVES_TO_TRASH])) {
+                SharesConfig::set($share_name, CONFIG_MODIFIED_MOVES_TO_TRASH, Config::get(CONFIG_MODIFIED_MOVES_TO_TRASH));
+            }
             if (isset($share_options[CONFIG_DRIVE_SELECTION_ALGORITHM])) {
                 foreach ($share_options[CONFIG_DRIVE_SELECTION_ALGORITHM] as $ds) {
                     $ds->update();
@@ -382,6 +392,7 @@ class Config {
     public static $config = array(
         CONFIG_LOG_LEVEL                   => Log::DEBUG,
         CONFIG_DELETE_MOVES_TO_TRASH       => TRUE,
+        CONFIG_MODIFIED_MOVES_TO_TRASH     => TRUE,
         CONFIG_LOG_MEMORY_USAGE            => FALSE,
         CONFIG_CHECK_FOR_OPEN_FILES        => TRUE,
         CONFIG_ALLOW_MULTIPLE_SP_PER_DRIVE => FALSE,


### PR DESCRIPTION
Before it would handle two scenarios:
1) When a file is deleted
2) When a file has been modified

Scenario 2 now has it's own configuration called modified_moves_to_trash

DEBIAN/Makefile was trying to remove a file called greyhole-mv which does not exist causing the script to fail, have commented out until gboudreau adds that script into the repo.
