### PR TITLE
Change to use insecure wide links

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -21,7 +21,7 @@ to become root, if you're not already (use `sudo -i` if you don't have the root 
 	Edit /etc/samba/smb.conf
 	Change or add the following values in the [global] section:
 
-		unix extensions = no
+	        allow insecure wide links = yes
 		wide links = yes
 
 	For each of your shares, add a 'dfree command' and 'vfs objects' lines, as seen below.


### PR DESCRIPTION
Instead of broadly disabling `unix extensions`, `allow insecure wide links` more directly targets the functionality that we want to enable. I've been using this option for over 6 months, and it seems to be working fine. I did, however, see a note on serverfault that said SELinux might block it from working properly. I don't use SELinux, so I'm not sure.

I don't think any conversion of pre-existing installs would be needed as the difference between the two options is minimal.