### PR TITLE
Samba 4.8 and other updates

### DIFF
--- a/DEBIAN/Makefile
+++ b/DEBIAN/Makefile
@@ -81,6 +81,7 @@ ifeq ($(ARCH), amd64)
 	install -m 0644 -D -p samba-module/bin/4.5/greyhole-x86_64.so $(DESTDIR)usr/lib64/greyhole/greyhole-samba45.so
 	install -m 0644 -D -p samba-module/bin/4.6/greyhole-x86_64.so $(DESTDIR)usr/lib64/greyhole/greyhole-samba46.so
 	install -m 0644 -D -p samba-module/bin/4.7/greyhole-x86_64.so $(DESTDIR)usr/lib64/greyhole/greyhole-samba47.so
+	install -m 0644 -D -p samba-module/bin/4.8/greyhole-x86_64.so $(DESTDIR)usr/lib64/greyhole/greyhole-samba48.so
 else
 ifeq ($(ARCH), armhf)
 		mkdir -p $(DESTDIR)usr/lib/greyhole/
@@ -95,6 +96,7 @@ ifeq ($(ARCH), armhf)
 		install -m 0644 -D -p samba-module/bin/4.5/greyhole-armhf.so $(DESTDIR)usr/lib/greyhole/greyhole-samba45.so
 		install -m 0644 -D -p samba-module/bin/4.6/greyhole-armhf.so $(DESTDIR)usr/lib/greyhole/greyhole-samba46.so
 		install -m 0644 -D -p samba-module/bin/4.7/greyhole-armhf.so $(DESTDIR)usr/lib/greyhole/greyhole-samba47.so
+		install -m 0644 -D -p samba-module/bin/4.8/greyhole-armhf.so $(DESTDIR)usr/lib/greyhole/greyhole-samba48.so
 else
 		mkdir -p $(DESTDIR)usr/lib/greyhole/
 		install -m 0644 -D -p samba-module/bin/3.4/greyhole-i386.so $(DESTDIR)usr/lib/greyhole/greyhole-samba34.so
@@ -108,5 +110,6 @@ else
 		install -m 0644 -D -p samba-module/bin/4.5/greyhole-i386.so $(DESTDIR)usr/lib/greyhole/greyhole-samba45.so
 		install -m 0644 -D -p samba-module/bin/4.6/greyhole-i386.so $(DESTDIR)usr/lib/greyhole/greyhole-samba46.so
 		install -m 0644 -D -p samba-module/bin/4.7/greyhole-i386.so $(DESTDIR)usr/lib/greyhole/greyhole-samba47.so
+		install -m 0644 -D -p samba-module/bin/4.8/greyhole-i386.so $(DESTDIR)usr/lib/greyhole/greyhole-samba48.so
 endif
 endif

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -76,10 +76,12 @@ elif [ "${SMB_VERSION}" = "4 6" ]; then
     LIB_FILE="greyhole-samba46.so"
 elif [ "${SMB_VERSION}" = "4 7" ]; then
     LIB_FILE="greyhole-samba47.so"
+elif [ "${SMB_VERSION}" = "4 8" ]; then
+    LIB_FILE="greyhole-samba48.so"
 else
     echo "Warning: Greyhole doesn't include a VFS module for your version of Samba (${SMB_VERSION})."
-    echo "We will try to use the VFS for Samba 4.7, but that might not work."
-    LIB_FILE="greyhole-samba47.so"
+    echo "We will try to use the VFS for Samba 4.8, but that might not work."
+    LIB_FILE="greyhole-samba48.so"
 fi
 
 SOURCE_LIB="${SOURCE_LIBDIR}/greyhole/${LIB_FILE}"

--- a/INSTALL
+++ b/INSTALL
@@ -73,6 +73,8 @@ If you know what you're doing, you should have no problem installing on any othe
 		if [ -d /usr/lib/x86_64-linux-gnu/samba/vfs/ ]; then ln -s samba-module/bin/4.6/greyhole-x86_64.so /usr/lib/x86_64-linux-gnu/samba/vfs/greyhole.so; elif [ -x /usr/lib64/samba/vfs/ ]; then ln -s samba-module/bin/4.6/greyhole-x86_64.so /usr/lib64/samba/vfs/greyhole.so; else ln -s samba-module/bin/4.6/greyhole-i386.so /usr/lib/samba/vfs/greyhole.so; fi
 	# For Samba 4.7: #
 		if [ -d /usr/lib/x86_64-linux-gnu/samba/vfs/ ]; then ln -s samba-module/bin/4.7/greyhole-x86_64.so /usr/lib/x86_64-linux-gnu/samba/vfs/greyhole.so; elif [ -x /usr/lib64/samba/vfs/ ]; then ln -s samba-module/bin/4.7/greyhole-x86_64.so /usr/lib64/samba/vfs/greyhole.so; else ln -s samba-module/bin/4.7/greyhole-i386.so /usr/lib/samba/vfs/greyhole.so; fi
+	# For Samba 4.8: #
+		if [ -d /usr/lib/x86_64-linux-gnu/samba/vfs/ ]; then ln -s samba-module/bin/4.8/greyhole-x86_64.so /usr/lib/x86_64-linux-gnu/samba/vfs/greyhole.so; elif [ -x /usr/lib64/samba/vfs/ ]; then ln -s samba-module/bin/4.8/greyhole-x86_64.so /usr/lib64/samba/vfs/greyhole.so; else ln -s samba-module/bin/4.8/greyhole-i386.so /usr/lib/samba/vfs/greyhole.so; fi
 
 	# Install the start script
 	# For SysVinit systems: install the initd script:
@@ -89,7 +91,7 @@ If you know what you're doing, you should have no problem installing on any othe
 	Ubuntu (15+): /etc/init.d/smbd restart
 	Debian: service samba restart
 
-3. For Samba >4.7: The greyhole.so files packaged with Greyhole won't work on your system.
+3. For Samba >4.8: The greyhole.so files packaged with Greyhole won't work on your system.
    You'll need to compile your own VFS module. You'll just need to compile vfs_greyhole.c, and install it.
 
    The following is for Samba 4.x. For Samba 3, see a previous version of this file: https://github.com/gboudreau/Greyhole/blob/0.9.35/INSTALL
@@ -97,13 +99,13 @@ If you know what you're doing, you should have no problem installing on any othe
 	Fedora: yum -y install patch gcc python-devel gnutls-devel
 	Ubuntu: apt-get -y install build-essential python-dev libgnutls-dev
 
-	SAMBA_VERSION=4.7.0 # Or whatever is the latest version of Samba4.
+	SAMBA_VERSION=4.8.0 # Or whatever is the latest version of Samba4.
 	wget http://samba.org/samba/ftp/stable/samba-${SAMBA_VERSION}.tar.gz
 	tar zxf samba-${SAMBA_VERSION}.tar.gz && rm -f samba-${SAMBA_VERSION}.tar.gz
 	cd samba-${SAMBA_VERSION}
-	cp ${GREYHOLE_INSTALL_DIR}/samba-module/vfs_greyhole-samba-4.7+.c source3/modules/vfs_greyhole.c
-	patch -p1 < ${GREYHOLE_INSTALL_DIR}/samba-module/wscript-samba-4.7.patch
-	./configure --enable-debug --enable-selftest --disable-symbol-versions --without-acl-support --without-ldap --without-ads && make
+	cp ${GREYHOLE_INSTALL_DIR}/samba-module/vfs_greyhole-samba-4.8.c source3/modules/vfs_greyhole.c
+	patch -p1 < ${GREYHOLE_INSTALL_DIR}/samba-module/wscript-samba-4.8.patch
+	./configure --enable-debug --enable-selftest --disable-symbol-versions --without-acl-support --without-ldap --without-ads --without-pam && make
 
     # Create a symlink in the Samba VFS modules dir pointing to the compiled VFS
     if [ -d /usr/lib/x86_64-linux-gnu ]; then LIBDIR=/usr/lib/x86_64-linux-gnu; elif [ "`uname -m`" = "x86_64" ]; then LIBDIR=/usr/lib64; else LIBDIR=/usr/lib; fi

--- a/build_vfs.sh
+++ b/build_vfs.sh
@@ -15,7 +15,7 @@ fi
 
 cd "$HOME"
 
-for version in 4.7.0 4.6.0 4.5.0 4.4.0 4.3.0 4.2.0 4.1.4 4.0.14 3.6.9 3.5.4 3.4.9; do
+for version in 4.8.0 4.7.0 4.6.0 4.5.0 4.4.0 4.3.0 4.2.0 4.1.4 4.0.14 3.6.9 3.5.4 3.4.9; do
 	echo "Working on samba-${version} ... "
 	if [ ! -d samba-${version} ]; then
 		curl -LO http://samba.org/samba/ftp/stable/samba-${version}.tar.gz && tar zxf samba-${version}.tar.gz && rm -f samba-${version}.tar.gz

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -271,6 +271,7 @@ static struct vfs_fn_pointers vfs_greyhole_fns = {
         .unlink_fn = greyhole_unlink
 };
 
+static_decl_vfs;
 NTSTATUS vfs_greyhole_init(TALLOC_CTX *ctx)
 {
 	NTSTATUS ret = smb_register_vfs(SMB_VFS_INTERFACE_VERSION, "greyhole", &vfs_greyhole_fns);

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -138,12 +138,12 @@ static ssize_t greyhole_write(vfs_handle_struct *handle, files_struct *fsp, cons
 	FILE *spoolf;
 	char filename[255];
 	struct timeval tp;
+	char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 
 	result = SMB_VFS_NEXT_WRITE(handle, fsp, data, count);
 
 	if (result >= 0) {
 		gettimeofday(&tp, (struct timezone *) NULL);
-		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 		snprintf(filename, 43 + strlen(share) + nDigits(fsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, fsp->fh->fd);
 		spoolf = fopen(filename, "wt");
 		fprintf(spoolf, "fwrite\n%s\n%d\n\n",
@@ -161,12 +161,12 @@ static ssize_t greyhole_pwrite(vfs_handle_struct *handle, files_struct *fsp, con
 	FILE *spoolf;
 	char filename[255];
 	struct timeval tp;
+	char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 
 	result = SMB_VFS_NEXT_PWRITE(handle, fsp, data, count, offset);
 
 	if (result >= 0) {
 		gettimeofday(&tp, (struct timezone *) NULL);
-		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 		snprintf(filename, 43 + strlen(share) + nDigits(fsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, fsp->fh->fd);
 		spoolf = fopen(filename, "wt");
 		fprintf(spoolf, "fwrite\n%s\n%d\n\n",
@@ -184,12 +184,12 @@ static ssize_t greyhole_recvfile(vfs_handle_struct *handle, int fromfd, files_st
 	FILE *spoolf;
 	char filename[255];
 	struct timeval tp;
+	char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 
 	result = SMB_VFS_NEXT_RECVFILE(handle, fromfd, tofsp, offset, n);
 
 	if (result >= 0) {
 		gettimeofday(&tp, (struct timezone *) NULL);
-		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
 		snprintf(filename, 43 + strlen(share) + nDigits(tofsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, tofsp->fh->fd);
 		spoolf = fopen(filename, "wt");
 		fprintf(spoolf, "fwrite\n%s\n%d\n\n",

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -53,18 +53,20 @@ static void gh_spoolf(const char* format, ...)
 
 static int nDigits(int i)
 {
-  int n,po10;
+	int n, po10;
 
-  if (i < 0) i = -i;
-  n=1;
-  po10=10;
-  while(i>=po10)
-  {
-    n++;
-    if (po10 > PO10_LIMIT) break;
-    po10*=10;
-  }
-  return n;
+	if (i < 0) i = -i;
+
+	n = 1;
+	po10 = 10;
+
+	while(i >= po10) {
+		n++;
+		if (po10 > PO10_LIMIT) break;
+		po10 *= 10;
+	}
+
+	return n;
 }
 
 /* Implementation of vfs_ops.  Pass everything on to the default

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -72,19 +72,6 @@ static int nDigits(int i)
 /* Implementation of vfs_ops.  Pass everything on to the default
 operation but log event first. */
 
-static int greyhole_connect(vfs_handle_struct *handle, const char *svc, const char *user)
-{
-	int result;
-
-	if (!handle) {
-		return -1;
-	}
-
-	result = SMB_VFS_NEXT_CONNECT(handle, svc, user);
-
-	return result;
-}
-
 static int greyhole_mkdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname, mode_t mode)
 {
 	int result;
@@ -252,10 +239,6 @@ static int greyhole_unlink(vfs_handle_struct *handle, const struct smb_filename 
 /* VFS operations */
 
 static struct vfs_fn_pointers vfs_greyhole_fns = {
-
-        /* Disk operations */
-
-        .connect_fn = greyhole_connect,
 
         /* Directory operations */
 

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -29,19 +29,6 @@ static int vfs_greyhole_debug_level = DBGC_VFS;
 #undef DBGC_CLASS
 #define DBGC_CLASS vfs_greyhole_debug_level
 
-/* Function prototypes */
-
-static int greyhole_connect(vfs_handle_struct *handle, const char *svc, const char *user);
-static int greyhole_mkdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname, mode_t mode);
-static int greyhole_rmdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname);
-static int greyhole_open(vfs_handle_struct *handle, struct smb_filename *fname, files_struct *fsp, int flags, mode_t mode);
-static ssize_t greyhole_write(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count);
-static ssize_t greyhole_pwrite(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count, off_t offset);
-static ssize_t greyhole_recvfile(vfs_handle_struct *handle, int fromfd, files_struct *tofsp, off_t offset, size_t n);
-static int greyhole_close(vfs_handle_struct *handle, files_struct *fsp);
-static int greyhole_rename(vfs_handle_struct *handle, const struct smb_filename *oldname, const struct smb_filename *newname);
-static int greyhole_unlink(vfs_handle_struct *handle, const struct smb_filename *path);
-
 /* Save formated string to Greyhole spool */
 
 static void gh_spoolf(const char* format, ...)
@@ -61,30 +48,6 @@ static void gh_spoolf(const char* format, ...)
 
 	fclose(spoolf);
 }
-
-/* VFS operations */
-
-static struct vfs_fn_pointers vfs_greyhole_fns = {
-
-	/* Disk operations */
-
-	.connect_fn = greyhole_connect,
-
-	/* Directory operations */
-
-	.mkdir_fn = greyhole_mkdir,
-	.rmdir_fn = greyhole_rmdir,
-
-	/* File operations */
-
-	.open_fn = greyhole_open,
-	.write_fn = greyhole_write,
-	.pwrite_fn = greyhole_pwrite,
-	.recvfile_fn = greyhole_recvfile,
-	.close_fn = greyhole_close,
-	.rename_fn = greyhole_rename,
-	.unlink_fn = greyhole_unlink
-};
 
 #define PO10_LIMIT (INT_MAX/10)
 
@@ -284,7 +247,30 @@ static int greyhole_unlink(vfs_handle_struct *handle, const struct smb_filename 
 	return result;
 }
 
-NTSTATUS vfs_greyhole_init(TALLOC_CTX *ctx);
+/* VFS operations */
+
+static struct vfs_fn_pointers vfs_greyhole_fns = {
+
+        /* Disk operations */
+
+        .connect_fn = greyhole_connect,
+
+        /* Directory operations */
+
+        .mkdir_fn = greyhole_mkdir,
+        .rmdir_fn = greyhole_rmdir,
+
+        /* File operations */
+
+        .open_fn = greyhole_open,
+        .write_fn = greyhole_write,
+        .pwrite_fn = greyhole_pwrite,
+        .recvfile_fn = greyhole_recvfile,
+        .close_fn = greyhole_close,
+        .rename_fn = greyhole_rename,
+        .unlink_fn = greyhole_unlink
+};
+
 NTSTATUS vfs_greyhole_init(TALLOC_CTX *ctx)
 {
 	NTSTATUS ret = smb_register_vfs(SMB_VFS_INTERFACE_VERSION, "greyhole", &vfs_greyhole_fns);

--- a/samba-module/vfs_greyhole-samba-4.8.c
+++ b/samba-module/vfs_greyhole-samba-4.8.c
@@ -1,0 +1,304 @@
+/*
+Copyright 2009-2014 Guillaume Boudreau, Edgars Binans
+
+This file is part of Greyhole.
+
+It was created based on vfs_extd_audit.c, by Tim Potter, Alexander
+Bokovoy, John H Terpstra & Stefan (metze) Metzmacher.
+
+Greyhole is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Greyhole is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Greyhole.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "includes.h"
+#include "system/filesys.h"
+#include "smbd/smbd.h"
+
+static int vfs_greyhole_debug_level = DBGC_VFS;
+
+#undef DBGC_CLASS
+#define DBGC_CLASS vfs_greyhole_debug_level
+
+/* Function prototypes */
+
+static int greyhole_connect(vfs_handle_struct *handle, const char *svc, const char *user);
+static int greyhole_mkdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname, mode_t mode);
+static int greyhole_rmdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname);
+static int greyhole_open(vfs_handle_struct *handle, struct smb_filename *fname, files_struct *fsp, int flags, mode_t mode);
+static ssize_t greyhole_write(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count);
+static ssize_t greyhole_pwrite(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count, off_t offset);
+static ssize_t greyhole_recvfile(vfs_handle_struct *handle, int fromfd, files_struct *tofsp, off_t offset, size_t n);
+static int greyhole_close(vfs_handle_struct *handle, files_struct *fsp);
+static int greyhole_rename(vfs_handle_struct *handle, const struct smb_filename *oldname, const struct smb_filename *newname);
+static int greyhole_unlink(vfs_handle_struct *handle, const struct smb_filename *path);
+
+/* Save formated string to Greyhole spool */
+
+static void gh_spoolf(const char* format, ...)
+{
+	FILE *spoolf;
+	char filename[38];
+	struct timeval tp;
+	va_list args;
+
+	gettimeofday(&tp, (struct timezone *) NULL);
+	snprintf(filename, 37, "/var/spool/greyhole/%.0f", ((double) (tp.tv_sec)*1000000.0) + (((double) tp.tv_usec)));
+	spoolf = fopen(filename, "wt");
+
+	va_start(args, format);
+	vfprintf(spoolf, format, args);
+	va_end(args);
+
+	fclose(spoolf);
+}
+
+/* VFS operations */
+
+static struct vfs_fn_pointers vfs_greyhole_fns = {
+
+	/* Disk operations */
+
+	.connect_fn = greyhole_connect,
+
+	/* Directory operations */
+
+	.mkdir_fn = greyhole_mkdir,
+	.rmdir_fn = greyhole_rmdir,
+
+	/* File operations */
+
+	.open_fn = greyhole_open,
+	.write_fn = greyhole_write,
+	.pwrite_fn = greyhole_pwrite,
+	.recvfile_fn = greyhole_recvfile,
+	.close_fn = greyhole_close,
+	.rename_fn = greyhole_rename,
+	.unlink_fn = greyhole_unlink
+};
+
+#define PO10_LIMIT (INT_MAX/10)
+
+static int nDigits(int i)
+{
+  int n,po10;
+
+  if (i < 0) i = -i;
+  n=1;
+  po10=10;
+  while(i>=po10)
+  {
+    n++;
+    if (po10 > PO10_LIMIT) break;
+    po10*=10;
+  }
+  return n;
+}
+
+/* Implementation of vfs_ops.  Pass everything on to the default
+operation but log event first. */
+
+static int greyhole_connect(vfs_handle_struct *handle, const char *svc, const char *user)
+{
+	int result;
+
+	if (!handle) {
+		return -1;
+	}
+
+	result = SMB_VFS_NEXT_CONNECT(handle, svc, user);
+
+	return result;
+}
+
+static int greyhole_mkdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname, mode_t mode)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_MKDIR(handle, smb_fname, mode);
+
+	if (result >= 0) {
+		gh_spoolf("mkdir\n%s\n%s\n\n",
+			lp_servicename(talloc_tos(), handle->conn->params->service),
+			smb_fname->base_name);
+	}
+
+	return result;
+}
+
+static int greyhole_rmdir(vfs_handle_struct *handle, const struct smb_filename *smb_fname)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_RMDIR(handle, smb_fname);
+
+	if (result >= 0) {
+		gh_spoolf("rmdir\n%s\n%s\n\n",
+			lp_servicename(talloc_tos(), handle->conn->params->service),
+			smb_fname->base_name);
+	}
+
+	return result;
+}
+
+static int greyhole_open(vfs_handle_struct *handle, struct smb_filename *fname, files_struct *fsp, int flags, mode_t mode)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_OPEN(handle, fname, fsp, flags, mode);
+
+	if (result >= 0) {
+		if ((flags & O_WRONLY) || (flags & O_RDWR)) {
+			gh_spoolf("open\n%s\n%s\n%d\n%s\n",
+				lp_servicename(talloc_tos(), handle->conn->params->service),
+				fname->base_name,
+				result,
+				"for writing ");
+		}
+	}
+
+	return result;
+}
+
+static ssize_t greyhole_write(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count)
+{
+	ssize_t result;
+	FILE *spoolf;
+	char filename[255];
+	struct timeval tp;
+
+	result = SMB_VFS_NEXT_WRITE(handle, fsp, data, count);
+
+	if (result >= 0) {
+		gettimeofday(&tp, (struct timezone *) NULL);
+		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
+		snprintf(filename, 43 + strlen(share) + nDigits(fsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, fsp->fh->fd);
+		spoolf = fopen(filename, "wt");
+		fprintf(spoolf, "fwrite\n%s\n%d\n\n",
+			share,
+			fsp->fh->fd);
+		fclose(spoolf);
+	}
+
+	return result;
+}
+
+static ssize_t greyhole_pwrite(vfs_handle_struct *handle, files_struct *fsp, const void *data, size_t count, off_t offset)
+{
+	ssize_t result;
+	FILE *spoolf;
+	char filename[255];
+	struct timeval tp;
+
+	result = SMB_VFS_NEXT_PWRITE(handle, fsp, data, count, offset);
+
+	if (result >= 0) {
+		gettimeofday(&tp, (struct timezone *) NULL);
+		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
+		snprintf(filename, 43 + strlen(share) + nDigits(fsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, fsp->fh->fd);
+		spoolf = fopen(filename, "wt");
+		fprintf(spoolf, "fwrite\n%s\n%d\n\n",
+			share,
+			fsp->fh->fd);
+		fclose(spoolf);
+	}
+
+	return result;
+}
+
+static ssize_t greyhole_recvfile(vfs_handle_struct *handle, int fromfd, files_struct *tofsp, off_t offset, size_t n)
+{
+	ssize_t result;
+	FILE *spoolf;
+	char filename[255];
+	struct timeval tp;
+
+	result = SMB_VFS_NEXT_RECVFILE(handle, fromfd, tofsp, offset, n);
+
+	if (result >= 0) {
+		gettimeofday(&tp, (struct timezone *) NULL);
+		char *share = lp_servicename(talloc_tos(), handle->conn->params->service);
+		snprintf(filename, 43 + strlen(share) + nDigits(tofsp->fh->fd), "/var/spool/greyhole/mem/%.0f-%s-%d", ((double) (tp.tv_sec)*1000000.0), share, tofsp->fh->fd);
+		spoolf = fopen(filename, "wt");
+		fprintf(spoolf, "fwrite\n%s\n%d\n\n",
+			share,
+			tofsp->fh->fd);
+		fclose(spoolf);
+	}
+
+	return result;
+}
+
+static int greyhole_close(vfs_handle_struct *handle, files_struct *fsp)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_CLOSE(handle, fsp);
+
+	if (result >= 0) {
+		gh_spoolf("close\n%s\n%d\n\n",
+			lp_servicename(talloc_tos(), handle->conn->params->service),
+			fsp->fh->fd);
+	}
+
+	return result;
+}
+
+static int greyhole_rename(vfs_handle_struct *handle, const struct smb_filename *oldname, const struct smb_filename *newname)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_RENAME(handle, oldname, newname);
+
+	if (result >= 0) {
+		gh_spoolf("rename\n%s\n%s\n%s\n\n",
+			lp_servicename(talloc_tos(), handle->conn->params->service),
+			oldname->base_name,
+			newname->base_name);
+	}
+
+	return result;
+}
+
+static int greyhole_unlink(vfs_handle_struct *handle, const struct smb_filename *path)
+{
+	int result;
+
+	result = SMB_VFS_NEXT_UNLINK(handle, path);
+
+	if (result >= 0) {
+		gh_spoolf("unlink\n%s\n%s\n\n",
+			lp_servicename(talloc_tos(), handle->conn->params->service),
+			path->base_name);
+	}
+
+	return result;
+}
+
+NTSTATUS vfs_greyhole_init(TALLOC_CTX *ctx);
+NTSTATUS vfs_greyhole_init(TALLOC_CTX *ctx)
+{
+	NTSTATUS ret = smb_register_vfs(SMB_VFS_INTERFACE_VERSION, "greyhole", &vfs_greyhole_fns);
+
+	if (!NT_STATUS_IS_OK(ret))
+		return ret;
+
+	vfs_greyhole_debug_level = debug_add_class("greyhole");
+	if (vfs_greyhole_debug_level == -1) {
+		vfs_greyhole_debug_level = DBGC_VFS;
+		DEBUG(0, ("vfs_greyhole: Couldn't register custom debugging class!\n"));
+	} else {
+		DEBUG(10, ("vfs_greyhole: Debug class number of 'greyhole': %d\n", vfs_greyhole_debug_level));
+	}
+
+	return ret;
+}

--- a/samba-module/wscript-samba-4.8.patch
+++ b/samba-module/wscript-samba-4.8.patch
@@ -1,0 +1,31 @@
+diff -Naur a/source3/modules/wscript_build b/source3/modules/wscript_build
+--- a/source3/modules/wscript_build     2018-02-12 05:27:16.000000000 -0500
++++ b/source3/modules/wscript_build     2018-04-20 09:48:58.617118748 -0400
+@@ -434,6 +434,14 @@
+                  internal_module=bld.SAMBA3_IS_STATIC_MODULE('vfs_media_harmony'),
+                  enabled=bld.SAMBA3_IS_ENABLED_MODULE('vfs_media_harmony'))
+
++bld.SAMBA3_MODULE('vfs_greyhole',
++                 subsystem='vfs',
++                 source='vfs_greyhole.c',
++                 deps='',
++                 init_function='',
++                 internal_module=bld.SAMBA3_IS_STATIC_MODULE('vfs_greyhole'),
++                 enabled=bld.SAMBA3_IS_ENABLED_MODULE('vfs_greyhole'))
++
+ bld.SAMBA3_MODULE('vfs_unityed_media',
+                  subsystem='vfs',
+                  source='vfs_unityed_media.c',
+diff -Naur a/source3/wscript b/source3/wscript
+--- a/source3/wscript   2018-03-01 15:18:10.000000000 -0500
++++ b/source3/wscript   2018-04-20 09:49:25.510453161 -0400
+@@ -1669,7 +1669,7 @@
+                                       vfs_readahead vfs_xattr_tdb
+                                       vfs_streams_xattr vfs_streams_depot vfs_acl_xattr vfs_acl_tdb
+                                       vfs_preopen vfs_catia
+-                                      vfs_media_harmony vfs_unityed_media vfs_fruit vfs_shell_snap
++                                      vfs_media_harmony vfs_greyhole vfs_unityed_media vfs_fruit vfs_shell_snap
+                                       vfs_commit vfs_worm vfs_crossrename vfs_linux_xfs_sgid
+                                       vfs_time_audit vfs_offline vfs_virusfilter
+                                   '''))
+


### PR DESCRIPTION
I've updated the VFS module and build instructions for Samba 4.8. I've also included a few updates to the module. They are pulled from the vfs_audit.c's git history. It looks like they are just structure changes and no actual code changes. (The other changes didn't apply to any of the functions we use). I also moved some variable declarations in order to fix some developer warnings on build. `static_decl_vfs` should be backwards compatible all the way back to Samba 4.4.0. I've been using these changes with Samba 4.7 for about 6 months, but I'll only push these changes to Samba 4.8's module.

It seemed like the connect function was never used. I'm not sure if you had an idea for that or not, but I removed it so GH wasn't called on every connect, even if it wasn't doing anything.

Finally, I've updated the build scripts. I did, however, have some difficulty building on 4.8. I had to remove `--without-ldap` because it was crashing. (See https://bugzilla.samba.org/show_bug.cgi?id=13331)