### PR TITLE
Exemplary change for fixing compiling error

### DIFF
--- a/samba-module/vfs_greyhole-samba-4.10.c
+++ b/samba-module/vfs_greyhole-samba-4.10.c
@@ -73,7 +73,8 @@ void compute_md5(const char *str, char *out) {
 	MD5Update(&ctx, str, strlen(str));
 	MD5Final(hash, &ctx);
 
-    for (int n = 0; n < 16; ++n) {
+    int n;
+    for (n = 0; n < 16; ++n) {
         snprintf(&(out[n*2]), 3, "%02x", (unsigned int)hash[n]);
     }
 }


### PR DESCRIPTION
When I compile greyhole module on my clear os system, it will always fail at this position because the declaration inside for like for (int n=...) is allowed for C99 upwards and it will break the build every time...